### PR TITLE
Alerta web 0.1.3

### DIFF
--- a/charts/alerta-web/Chart.yaml
+++ b/charts/alerta-web/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "8.7.0"
 description: A Helm chart for Kubernetes
 name: alerta-web
-version: 0.1.2
+version: 0.1.3
 home: https://github.com/hayk96/alerta-web
 icon: https://raw.githubusercontent.com/hayk96/alerta-web/main/logo/mstile-310x310.png.png
 dependencies:

--- a/charts/alerta-web/Chart.yaml
+++ b/charts/alerta-web/Chart.yaml
@@ -8,7 +8,7 @@ icon: https://raw.githubusercontent.com/hayk96/alerta-web/main/logo/mstile-310x3
 dependencies:
   - name: postgresql
     version: "10.16.2"
-    repository: https://charts.bitnami.com/bitnami
+    repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
     condition: postgresql.enabled
 sources:
   - https://github.com/alerta/alerta

--- a/charts/alerta-web/templates/configmap.yaml
+++ b/charts/alerta-web/templates/configmap.yaml
@@ -8,6 +8,10 @@ data:
     {{- end }}
     {{ if .Values.postgresql.enabled -}}
     DATABASE_URL = "postgresql://{{ .Values.postgresql.postgresqlUsername }}:{{ .Values.postgresql.postgresqlPassword }}@{{ .Release.Name }}-postgresql:5432/{{ .Values.postgresql.postgresqlDatabase }}"
+    {{ else if and (.Values.useExistingDatabase) (eq .Values.useExistingDatabase.type "postgresql") }}
+    {{ if eq .Values.useExistingDatabase.type "postgresql" }}
+    DATABASE_URL = "postgresql://{{- if .Values.useExistingDatabase.auth.enabled -}}{{ .Values.useExistingDatabase.auth.username }}:{{ .Values.useExistingDatabase.auth.password }}@{{- end -}}{{ .Values.useExistingDatabase.endpoint }}/{{ .Values.useExistingDatabase.database }}"
+    {{- end }}
     {{- end }}
 {{- if .Values.alertaWebUIConfig }}
   config.js: |

--- a/charts/alerta-web/values.yaml
+++ b/charts/alerta-web/values.yaml
@@ -82,3 +82,13 @@ postgresql:
   persistence:
     enabled: true
     size: 1Gi
+
+# Use already existing database. Currently, supported type is Postgres with version 11.x
+useExistingDatabase: {}
+#  type: postgresql
+#  endpoint: example-postgresql.default.svc:5432
+#  database: EXISTING_DATABASE_NAME
+#  auth:
+#    enabled: true
+#    username: EXISTING_USERNAME
+#    password: EXISTING_PASSWORD


### PR DESCRIPTION
**What this PR does / why we need it:**
- This release includes support for using the existing Postgres database with version `11.x`  only. 